### PR TITLE
Add Docker support for one-command setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__
+*.pyc
+*.pyo
+*.egg-info
+.venv
+venv
+
+# Node
+node_modules
+frontend/node_modules
+frontend/.next
+
+# Logs
+*.log
+backend/backend.log
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Docker
+Dockerfile*
+docker-compose*.yml
+.dockerignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,15 @@ This section guides you through submitting an enhancement suggestion, including 
     npm run dev
     ```
 
+### Alternative: Docker Setup
+
+If you prefer using Docker, you can run the entire stack with a single command:
+```bash
+docker compose -f docker/docker-compose.yml up --build
+```
+-   Backend will be available at `http://localhost:8000`
+-   Frontend will be available at `http://localhost:3000`
+
 ## 🎨 Styleguides
 
 ### Python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,15 @@ This section guides you through submitting an enhancement suggestion, including 
     npm run dev
     ```
 
+### Alternative: Docker Setup
+
+If you prefer using Docker, you can run the entire stack with:
+```bash
+make build
+```
+-   Dashboard will be available at `http://localhost:3000`
+-   Use `make logs` to view output, `make down` to stop
+
 ## 🎨 Styleguides
 
 ### Python

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+COMPOSE_FILE := docker/docker-compose.yml
+
+.PHONY: up down build logs restart clean help
+
+up:
+	docker compose -f $(COMPOSE_FILE) up -d
+
+build:
+	docker compose -f $(COMPOSE_FILE) up --build -d
+
+down:
+	docker compose -f $(COMPOSE_FILE) down
+
+logs:
+	docker compose -f $(COMPOSE_FILE) logs -f
+
+restart:
+	docker compose -f $(COMPOSE_FILE) restart
+
+clean:
+	docker compose -f $(COMPOSE_FILE) down --rmi all --volumes --remove-orphans
+
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  up        Start the application"
+	@echo "  build     Build and start the application"
+	@echo "  down      Stop the application"
+	@echo "  logs      View logs (follow mode)"
+	@echo "  restart   Restart the application"
+	@echo "  clean     Remove everything (containers, images, volumes)"
+	@echo "  help      Show this help message"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,27 @@ This project includes:
 -   **Backend**: Python, FastAPI, Uvicorn, Requests
 -   **Frontend**: TypeScript, Next.js, Tailwind CSS, shadcn/ui, Lucide React
 
-## 📦 Installation
+## 🐳 Docker Quickstart (Recommended)
+
+The easiest way to run the full application — no local Python or Node.js required:
+
+```bash
+git clone https://github.com/CarlosIbCu/polymarket-kalshi-btc-arbitrage-bot.git
+cd polymarket-kalshi-btc-arbitrage-bot
+make build
+```
+
+That's it! The dashboard will be available at `http://localhost:3000`.
+
+Other commands:
+```bash
+make up        # Start the application
+make down      # Stop the application
+make logs      # View logs
+make clean     # Remove everything (containers, images, volumes)
+```
+
+## 📦 Manual Installation
 
 ### Prerequisites
 -   Python 3.9+

--- a/README.md
+++ b/README.md
@@ -35,7 +35,24 @@ This project includes:
 -   **Backend**: Python, FastAPI, Uvicorn, Requests
 -   **Frontend**: TypeScript, Next.js, Tailwind CSS, shadcn/ui, Lucide React
 
-## 📦 Installation
+## 🐳 Docker Quickstart (Recommended)
+
+The easiest way to run the full application — no local Python or Node.js required:
+
+```bash
+git clone https://github.com/CarlosIbCu/polymarket-kalshi-btc-arbitrage-bot.git
+cd polymarket-kalshi-btc-arbitrage-bot
+docker compose -f docker/docker-compose.yml up --build
+```
+
+That's it! The dashboard will be available at `http://localhost:3000` and the API at `http://localhost:8000`.
+
+To stop the application:
+```bash
+docker compose -f docker/docker-compose.yml down
+```
+
+## 📦 Manual Installation
 
 ### Prerequisites
 -   Python 3.9+

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY backend/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend/ .
+
+EXPOSE 8000
+
+CMD ["python3", "api.py"]

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies first for layer caching
+COPY backend/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy backend source code
+COPY backend/ .
+
+EXPOSE 8000
+
+CMD ["python3", "api.py"]

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -1,0 +1,24 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install dependencies first for layer caching
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+# Copy frontend source code
+COPY frontend/ .
+
+# Build the Next.js app (downloads SWC binaries and produces standalone output)
+RUN npm run build
+
+EXPOSE 3000
+
+# Default API URL — points to the backend on the host via Docker port mapping
+# Since the frontend runs in the browser, this must resolve from the user's machine
+ENV NEXT_PUBLIC_API_URL=http://localhost:8000
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
+
+# Run the standalone server
+CMD ["node", ".next/standalone/server.js"]

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -1,0 +1,23 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend/ .
+
+ENV BACKEND_URL=http://backend:8000
+RUN npm run build
+
+RUN cp -r .next/static .next/standalone/.next/static && \
+    if [ -d public ]; then cp -r public .next/standalone/public; fi
+
+WORKDIR /app/.next/standalone
+
+EXPOSE 3000
+
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
+
+CMD ["node", "server.js"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  backend:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.backend
+    network_mode: host
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.frontend
+    network_mode: host
+    depends_on:
+      - backend
+    restart: unless-stopped

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  backend:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.backend
+    expose:
+      - "8000"
+    networks:
+      - app-network
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.frontend
+    ports:
+      - "3000:3000"
+    environment:
+      - BACKEND_URL=http://backend:8000
+    networks:
+      - app-network
+    depends_on:
+      - backend
+    restart: unless-stopped
+
+networks:
+  app-network:
+    driver: bridge

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -58,9 +58,11 @@ export default function Dashboard() {
   const [loading, setLoading] = useState(true)
   const [lastUpdated, setLastUpdated] = useState<Date>(new Date())
 
+  const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
+
   const fetchData = async () => {
     try {
-      const res = await fetch("http://localhost:8000/arbitrage")
+      const res = await fetch(`${API_URL}/arbitrage`)
       const json = await res.json()
       setData(json)
       setLastUpdated(new Date())

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -60,7 +60,7 @@ export default function Dashboard() {
 
   const fetchData = async () => {
     try {
-      const res = await fetch("http://localhost:8000/arbitrage")
+      const res = await fetch("/api/arbitrage")
       const json = await res.json()
       setData(json)
       setLastUpdated(new Date())

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: 'standalone',
 };
 
 export default nextConfig;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: 'standalone',
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${process.env.BACKEND_URL || 'http://localhost:8000'}/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Add Docker support so the entire app runs with `make build`.
## Changes
- `docker/` — Dockerfiles for backend (Python 3.11) and frontend (Node 20 standalone)
- `docker/docker-compose.yml` — Bridge network, only port 3000 exposed
- `Makefile` — `make up/down/build/logs/clean`
- `frontend/next.config.ts` — Standalone output + API proxy rewrites
- `frontend/app/page.tsx` — Relative `/api/arbitrage` fetch
- Updated README and CONTRIBUTING with Docker instructions

Backend is internal-only. Next.js rewrites proxy API calls through the frontend container.

Closes #12 